### PR TITLE
Don't allow a Resource / Queue name to start with "."

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -310,7 +310,7 @@ int matches(const char *pattern, const char *string) {
 int check_name(char *name) {
 	static char *allowed = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-";
 
-	if (strspn(name, allowed) != strlen(name))
+	if (strspn(name, allowed) != strlen(name) || *name == '.')
 		return 1;
 
 	return 0;


### PR DESCRIPTION
If a resource/queue gets created with a leading “.” and a job references that resource/queue then on a restart of the jersd service the demon will fail to start.


